### PR TITLE
Error handling while is busy

### DIFF
--- a/lib/pages/session_page.dart
+++ b/lib/pages/session_page.dart
@@ -77,6 +77,7 @@ class _SessionPageState extends State<SessionPage> {
                           textAlign: TextAlign.center
                         ),
                         onTap: () {
+                          if (MessageManager.busy) return;
                           MemoryManager.setSession(sessions[index]);
                           Navigator.of(context).pop();
                         },

--- a/lib/pages/session_page.dart
+++ b/lib/pages/session_page.dart
@@ -82,6 +82,7 @@ class _SessionPageState extends State<SessionPage> {
                           Navigator.of(context).pop();
                         },
                         onLongPress: () { // Rename session Dialog
+                          if (MessageManager.busy) return;
                           showDialog(
                             context: context,
                             builder: (context) {


### PR DESCRIPTION
I noticed that the app crashes when the user tries to switch sessions or rename, so I simply added some returns while it is busy.