### PR TITLE
unnecessary check

### DIFF
--- a/lib/widgets/page_bodies/chat_body.dart
+++ b/lib/widgets/page_bodies/chat_body.dart
@@ -81,10 +81,7 @@ class _ChatBodyState extends State<ChatBody> {
       );
       MessageManager.add(UniqueKey());
 
-      if (GenerationManager.remote && 
-        Host.url.isNotEmpty && 
-        model.parameters["remote_model"] != null
-      ) {
+      if (GenerationManager.remote && Host.url.isNotEmpty) {
         GenerationManager.prompt(MessageManager.promptController.text.trim());
         setState(() {
           MessageManager.busy = true;


### PR DESCRIPTION
I observed that this check

https://github.com/MaidFoundation/Maid/blob/7e478b7408960fb61d6b7878c70b6bbc3699b248/lib/widgets/page_bodies/chat_body.dart#L86C42

is already being handled at this line
https://github.com/MaidFoundation/Maid/blob/7e478b7408960fb61d6b7878c70b6bbc3699b248/lib/core/remote_generation.dart#L30 

so I removed it, allowing users to use the default ollama model without specifying a particular model.