### PR TITLE
home index on desktop ui

### DIFF
--- a/lib/pages/desktop_home.dart
+++ b/lib/pages/desktop_home.dart
@@ -17,27 +17,35 @@ class DesktopHomePage extends StatefulWidget {
 }
 
 class DesktopHomePageState extends State<DesktopHomePage> {
-  int? _selectedIndex;
+  int _selectedIndex = 0;
 
   Widget _getSelectedPage() {
     switch (_selectedIndex) {
       case 0:
-        return const Expanded(child: Scaffold(body: CharacterBody()));
-      case 1:
-        return const Expanded(child: Scaffold(body: SessionsBody()));
-      case 2:
-        return const Expanded(child: Scaffold(body: ModelBody()));
-      case 3:
-        return const Expanded(child: Scaffold(body: SettingsBody()));
-      case 4:
-        return const Expanded(child: Scaffold(body: AboutBody()));
-      default:
         return const Expanded(
           child: Scaffold(
             appBar: HomeAppBar(),
             body: ChatBody(),
           ),
         );
+      case 1:
+        return const Expanded(child: Scaffold(body: CharacterBody()));
+      case 2:
+        return const Expanded(child: Scaffold(body: SessionsBody()));
+      case 3:
+        return const Expanded(child: Scaffold(body: ModelBody()));
+      case 4:
+        return const Expanded(child: Scaffold(body: SettingsBody()));
+      case 5:
+        return const Expanded(child: Scaffold(body: AboutBody()));
+      default: 
+        return const Expanded(
+          child: Scaffold(
+            appBar: HomeAppBar(),
+            body: ChatBody(),
+          ),
+        );
+        
     }
   }
   
@@ -48,14 +56,20 @@ class DesktopHomePageState extends State<DesktopHomePage> {
         NavigationRail(
           onDestinationSelected: (int index) {
             setState(() {
-              if (_selectedIndex == index) {
-                _selectedIndex = null;
-              } else {
+              if (_selectedIndex != index) {
                 _selectedIndex = index;
               }
             });
           },
           destinations: <NavigationRailDestination>[
+            NavigationRailDestination(
+              icon: const Icon(Icons.home),
+              selectedIcon: Icon(
+                Icons.home,
+                color: Theme.of(context).colorScheme.secondary,
+              ),
+              label: const Text('Home'),
+            ),
             NavigationRailDestination(
               icon: const Icon(Icons.person),
               selectedIcon: Icon(


### PR DESCRIPTION
Previously, for example, when users clicked on 'Settings,' they had to click on the settings icon again to return at home (chatUI) . 
Now, the navigation navigation should be more user-friendly on desktop