### PR TITLE
convert RemoteDropdown to stateful widget

### DIFF
--- a/lib/core/remote_generation.dart
+++ b/lib/core/remote_generation.dart
@@ -113,7 +113,6 @@ class RemoteGeneration {
         }
       }
 
-      print(models);
       return models;
     } catch (e) {
       Logger.log('Error: $e');

--- a/lib/widgets/page_bodies/model_body.dart
+++ b/lib/widgets/page_bodies/model_body.dart
@@ -93,12 +93,13 @@ class _ModelBodyState extends State<ModelBody> {
                 headingText: 'Remote URL', 
                 labelText: 'Remote URL',
                 initialValue: Host.url,
-                onChanged: (value) {
+                onSubmitted: (value) {
                   Host.url = value;
-                },
+                  setState(() {});
+                } ,
               ),
               const SizedBox(height: 8.0),
-              const RemoteDropdown(),
+              RemoteDropdown(url: Host.url),
               const SizedBox(height: 20.0),
               Divider(
                 height: 20,

--- a/lib/widgets/settings_widgets/remote_dropdown.dart
+++ b/lib/widgets/settings_widgets/remote_dropdown.dart
@@ -1,46 +1,71 @@
 import 'package:flutter/material.dart';
 import 'package:maid/core/remote_generation.dart';
+import 'package:maid/static/host.dart';
 import 'package:maid/types/model.dart';
 
-class RemoteDropdown extends StatelessWidget {
-  const RemoteDropdown({super.key});
+class RemoteDropdown extends StatefulWidget {
+  final String url;
+
+  const RemoteDropdown({super.key, required this.url});
 
   @override
+  State<RemoteDropdown> createState() => _RemoteDropdownState();
+}
+
+class _RemoteDropdownState extends State<RemoteDropdown> {
+  late final ValueNotifier<String> _urlNotifier;
+
+  @override
+  void initState() {
+    super.initState();
+    _urlNotifier = ValueNotifier<String>(Host.url);
+  }
+  
+  @override
   Widget build(BuildContext context) {
-    return ListTile(
-      title: Row(
-        children: [
-          const Expanded(
-            child: Text("Remote Model"),
-          ),
-          FutureBuilder<List<String>>(
-            future: RemoteGeneration.getModels(),
-            builder: (BuildContext context, AsyncSnapshot<List<String>> snapshot) {
-              if (snapshot.data == null) {
-                return const SizedBox(height: 8.0);
-              }
-              
-              List<DropdownMenuEntry<String>> dropdownEntries = snapshot.data!
-                .map((String modelName) => DropdownMenuEntry<String>(
-                      value: modelName,
-                      label: modelName,
-                    ))
-                .toList();
+    return ValueListenableBuilder<String>(
+      valueListenable: _urlNotifier,
+      builder: (context, url, child) {
+        return ListTile(
+        title: Row(
+          children: [
+            const Expanded(
+              child: Text("Remote Model"),
+            ),
+            FutureBuilder<List<String>>(
+              future: RemoteGeneration.getModels(),
+              builder: (BuildContext context, AsyncSnapshot<List<String>> snapshot) {
+                if (snapshot.data == null) {
+                  return const SizedBox(height: 8.0);
+                }
                 
-              return DropdownMenu<String>(
-                dropdownMenuEntries: dropdownEntries,
-                onSelected: (String? value) {
-                  if (value != null) {
-                    model.parameters["remote_model"] = value;
-                  }
-                },
-                width: 200,
-              );
-            },
-          ),
-        ],
-      )
-    );
+                List<DropdownMenuEntry<String>> dropdownEntries = snapshot.data!
+                  .map((String modelName) => DropdownMenuEntry<String>(
+                        value: modelName,
+                        label: modelName,
+                      ))
+                  .toList();
+                  
+                return DropdownMenu<String>(
+                  dropdownMenuEntries: dropdownEntries,
+                  onSelected: (String? value) {
+                    if (value != null) {
+                      model.parameters["remote_model"] = value;
+                    }
+                  },
+                  width: 200,
+                );
+              },
+            ),
+          ],
+        )
+      );
+    });
   }
 
+  @override
+  void dispose() {
+    _urlNotifier.dispose();
+    super.dispose();
+  }
 }


### PR DESCRIPTION
I noticed that when users change the remote URL, the remote dropdown does not update in real-time. 
This necessitates users to navigate back to the model page to see the dropdown is filled. 
To address this issue, I have now implemented the update within the submit form, ensuring a seamless experience for users.